### PR TITLE
ci: write release notes to the project directory that is being packed…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
           path_to_commits: ./commit_logs.json
       - name: Write Release Notes to File
         run: | 
-          echo "${{ steps.release_notes.outputs.release_notes }}" > release_notes.txt
+          echo "${{ steps.release_notes.outputs.release_notes }}" > "${{ env.project_path }}/release_notes.txt"
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:

--- a/src/OpenAPI.ParameterStyleParsers/OpenAPI.ParameterStyleParsers.csproj
+++ b/src/OpenAPI.ParameterStyleParsers/OpenAPI.ParameterStyleParsers.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<PackageReleaseNotes>$([System.IO.File]::ReadAllText('$(MSBuildStartupDirectory)/release_notes.txt'))</PackageReleaseNotes>
+		<PackageReleaseNotes>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/release_notes.txt'))</PackageReleaseNotes>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageId>ParameterStyleParsers.OpenAPI</PackageId>


### PR DESCRIPTION
… as msbuild path is unreliable