### PR TITLE
Fix primitive parsing

### DIFF
--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Primitive;
@@ -11,6 +12,21 @@ internal static class PrimitiveJsonConverter
         out JsonNode? instance,
         [NotNullWhen(false)] out string? error)
     {
+        string GetWrongTypeError() => $"Value {value} is not a {jsonType}";
+        bool TryParse([NotNullWhen(true)] out JsonNode? jsonNode)
+        {
+            try
+            {
+                jsonNode = JsonNode.Parse(value);
+                return jsonNode != null;
+            }
+            catch (JsonException)
+            {
+                jsonNode = null;
+                return false;
+            }
+        }
+        
         switch (jsonType)
         {
             case Parameter.Types.String:
@@ -18,11 +34,42 @@ internal static class PrimitiveJsonConverter
                 error = null;
                 return true;
             case Parameter.Types.Number:
+                if (TryParse(out instance) &&
+                    instance.GetValueKind() is JsonValueKind.Number)
+                {
+                    error = null;
+                    return true;
+                }
+
+                instance = null;
+                error = GetWrongTypeError();
+                return false;
             case Parameter.Types.Boolean:
+                if (TryParse(out instance) &&
+                    instance.GetValueKind() is JsonValueKind.False or JsonValueKind.True)
+                {
+                    error = null;
+                    return true;
+                }
+
+                instance = null;
+                error = GetWrongTypeError();
+                return false;
             case Parameter.Types.Integer:
-                instance = JsonNode.Parse(value);
-                error = null;
-                return true;
+                if (TryParse(out instance) &&
+                    instance.GetValueKind() is JsonValueKind.Number &&
+                    (value == "-0" || 
+                     value.EndsWith(".0") || 
+                     (long.TryParse(value, out var integer) && 
+                      integer is <= 9007199254740992 and > -9007199254740992)))
+                {
+                    error = null;
+                    return true;
+                }
+
+                instance = null;
+                error = GetWrongTypeError();
+                return false;
             default:
                 error = $"Json type {jsonType} is not a primitive type, expected one of {string.Join(", ", Parameter.Types.Primitives)}";
                 instance = null;

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
@@ -12,7 +12,8 @@ internal static class PrimitiveJsonConverter
     /// <param name="value">Parameter styled value</param>
     /// <param name="jsonType">The expected json schema type</param>
     /// <param name="instance">The converted value.
-    /// Note: The converted value might not correspond to <param name="jsonType"></param> if <param name="value"></param>isn't</param>
+    /// Note: The converted value might not correspond to <paramref name="jsonType"/>
+    /// if <paramref name="value" /> isn't</param>
     /// <param name="error">An error if the value isn't convertable</param>
     /// <returns>True if the value was converted</returns>
     internal static bool TryConvert(

--- a/src/OpenAPI.ParameterStyleParsers/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
+++ b/src/OpenAPI.ParameterStyleParsers/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
@@ -7,38 +7,47 @@ namespace OpenAPI.ParameterStyleParsers.ParameterParsers.Primitive;
 
 internal static class PrimitiveJsonConverter
 {
+    /// <summary>
+    /// Converts a style parameter value to json
+    /// </summary>
+    /// <param name="value">Parameter styled value</param>
+    /// <param name="jsonType">The expected json schema type</param>
+    /// <param name="instance">The converted value.
+    /// Note: The converted value might not correspond to <paramref name="jsonType"/>
+    /// if <paramref name="value" /> isn't</param>
+    /// <param name="error">An error if the value isn't convertable</param>
+    /// <returns>True if the value was converted</returns>
     internal static bool TryConvert(
         string? value,
         InstanceType jsonType,
         out JsonNode? instance,
         [NotNullWhen(false)] out string? error)
     {
-        switch (jsonType)
+        instance = jsonType switch
         {
-            case InstanceType.String:
-                instance = JsonValue.Create(value);
-                error = null;
-                return true;
-            case InstanceType.Number:
-            case InstanceType.Boolean:
-            case InstanceType.Integer:
-            case InstanceType.Null:
-                try
-                {
-                    instance = value == null ? null : JsonNode.Parse(value);
-                    error = null;
-                    return true;
-                }
-                catch (JsonException)
-                {
-                    instance = null;
-                    error = $"Value {value} is not a {jsonType}";
-                    return false;
-                }
-            default:
-                error = $"Json type {Enum.GetName(jsonType)} is not a primitive type";
-                instance = null;
-                return false;
+            // Use string as-is if it is declared as a string.
+            // "1.2" can be both a number and a string, but it's formatted differently in json format,
+            // i.e. 1.2 or "1.2". We always want the latter if it is a string.
+            InstanceType.String => JsonValue.Create(value),
+            _ => Parse()
+        };
+        error = null;
+        return true;
+
+        JsonNode? Parse()
+        {
+            try
+            {
+                // The purpose of the converter is to convert parameter styled values
+                // to json values not to validate that the value is of a specific type
+                // or valid according to a schema, so we let it parse as-is
+                return value is null ? null : JsonNode.Parse(value);
+            }
+            // Value is not json formatted, so it will be treated as a string
+            catch (JsonException)
+            {
+                return JsonValue.Create(value);
+            }
         }
     }
 }

--- a/src/OpenAPI.ParameterStyleParsers/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
+++ b/src/OpenAPI.ParameterStyleParsers/ParameterParsers/Primitive/PrimitiveJsonConverter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using OpenAPI.ParameterStyleParsers.JsonSchema;
 
@@ -22,9 +23,18 @@ internal static class PrimitiveJsonConverter
             case InstanceType.Boolean:
             case InstanceType.Integer:
             case InstanceType.Null:
-                instance = value == null ? null : JsonNode.Parse(value);
-                error = null;
-                return true;
+                try
+                {
+                    instance = value == null ? null : JsonNode.Parse(value);
+                    error = null;
+                    return true;
+                }
+                catch (JsonException)
+                {
+                    instance = null;
+                    error = $"Value {value} is not a {jsonType}";
+                    return false;
+                }
             default:
                 error = $"Json type {Enum.GetName(jsonType)} is not a primitive type";
                 instance = null;

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Primitive;
+﻿using OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Primitive;
 
 namespace OpenAPI.ParameterStyleParsers.UnitTests.OpenAPI_20;
 
@@ -7,14 +6,8 @@ public class PrimitiveJsonConverterTests
 {
     [Theory]
     [InlineData("integer", "one")]
-    [InlineData("integer", "false")]
-    [InlineData("integer", "1.5")]
-    [InlineData("integer",  "-9007199254740992")]
-    [InlineData("integer",  "9007199254740993")]
     [InlineData("number", "one")]
-    [InlineData("number", "false")]
-    [InlineData("boolean", "test")]
-    [InlineData("boolean", "1")]
+    [InlineData("boolean", "one")]
     public void InvalidTypes_Converting_ReportError(string type, string value)
     {
         PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
@@ -24,31 +17,30 @@ public class PrimitiveJsonConverterTests
     }
     
     [Theory]
-    [InlineData("integer", "1", JsonValueKind.Number)]
-    [InlineData("integer", "1.0", JsonValueKind.Number)]
-    [InlineData("integer", "-0", JsonValueKind.Number)]
-    [InlineData("integer",  "-9007199254740991", JsonValueKind.Number)]
-    [InlineData("integer",  "9007199254740992", JsonValueKind.Number)]
-    [InlineData("number", "1", JsonValueKind.Number)]
-    [InlineData("number", "1.0", JsonValueKind.Number)]
-    [InlineData("number", "-0", JsonValueKind.Number)]
-    [InlineData("number",  "-9007199254740991", JsonValueKind.Number)]
-    [InlineData("number",  "9007199254740992", JsonValueKind.Number)]
-    [InlineData("number",  "1.5", JsonValueKind.Number)]
-    [InlineData("boolean",  "true", JsonValueKind.True)]
-    [InlineData("boolean",  "false", JsonValueKind.False)]
-    [InlineData("string",  "false", JsonValueKind.String)]
-    [InlineData("string",  "foo", JsonValueKind.String)]
-    [InlineData("string",  "1", JsonValueKind.String)]
-    [InlineData("string",  "", JsonValueKind.String)]
-    [InlineData("string",  "1.5", JsonValueKind.String)]
-    public void ValidTypes_Converting_ConvertsSuccessfully(string type, string value, JsonValueKind jsonValueKind)
+    [InlineData("integer", "1")]
+    [InlineData("integer", "1.0")]
+    [InlineData("integer", "-0")]
+    [InlineData("integer",  "-9007199254740991")]
+    [InlineData("integer",  "9007199254740992")]
+    [InlineData("number", "1")]
+    [InlineData("number", "1.0")]
+    [InlineData("number", "-0")]
+    [InlineData("number",  "-9007199254740991")]
+    [InlineData("number",  "9007199254740992")]
+    [InlineData("number",  "1.5")]
+    [InlineData("boolean",  "true")]
+    [InlineData("boolean",  "false")]
+    [InlineData("string",  "false")]
+    [InlineData("string",  "foo")]
+    [InlineData("string",  "1")]
+    [InlineData("string",  "")]
+    [InlineData("string",  "1.5")]
+    public void ValidTypes_Converting_ConvertsSuccessfully(string type, string value)
     {
         PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
             .Should().BeTrue();
         error.Should().BeNull();
         instance.Should().NotBeNull();
         instance.ToJsonString().Trim('"').Should().Be(value);
-        instance.GetValueKind().Should().Be(jsonValueKind);
     }
 }

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Text.Json;
+using OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Primitive;
+
+namespace OpenAPI.ParameterStyleParsers.UnitTests.OpenAPI_20;
+
+public class PrimitiveJsonConverterTests
+{
+    [Theory]
+    [InlineData("integer", "one")]
+    [InlineData("integer", "false")]
+    [InlineData("integer", "1.5")]
+    [InlineData("integer",  "-9007199254740992")]
+    [InlineData("integer",  "9007199254740993")]
+    [InlineData("number", "one")]
+    [InlineData("number", "false")]
+    [InlineData("boolean", "test")]
+    [InlineData("boolean", "1")]
+    public void InvalidTypes_Converting_ReportError(string type, string value)
+    {
+        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
+            .Should().BeFalse();
+        instance.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+    
+    [Theory]
+    [InlineData("integer", "1", JsonValueKind.Number)]
+    [InlineData("integer", "1.0", JsonValueKind.Number)]
+    [InlineData("integer", "-0", JsonValueKind.Number)]
+    [InlineData("integer",  "-9007199254740991", JsonValueKind.Number)]
+    [InlineData("integer",  "9007199254740992", JsonValueKind.Number)]
+    [InlineData("number", "1", JsonValueKind.Number)]
+    [InlineData("number", "1.0", JsonValueKind.Number)]
+    [InlineData("number", "-0", JsonValueKind.Number)]
+    [InlineData("number",  "-9007199254740991", JsonValueKind.Number)]
+    [InlineData("number",  "9007199254740992", JsonValueKind.Number)]
+    [InlineData("number",  "1.5", JsonValueKind.Number)]
+    [InlineData("boolean",  "true", JsonValueKind.True)]
+    [InlineData("boolean",  "false", JsonValueKind.False)]
+    [InlineData("string",  "false", JsonValueKind.String)]
+    [InlineData("string",  "foo", JsonValueKind.String)]
+    [InlineData("string",  "1", JsonValueKind.String)]
+    [InlineData("string",  "", JsonValueKind.String)]
+    [InlineData("string",  "1.5", JsonValueKind.String)]
+    public void ValidTypes_Converting_ConvertsSuccessfully(string type, string value, JsonValueKind jsonValueKind)
+    {
+        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
+            .Should().BeTrue();
+        error.Should().BeNull();
+        instance.Should().NotBeNull();
+        instance.ToJsonString().Trim('"').Should().Be(value);
+        instance.GetValueKind().Should().Be(jsonValueKind);
+    }
+}

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/PrimitiveJsonConverterTests.cs
@@ -5,42 +5,38 @@ namespace OpenAPI.ParameterStyleParsers.UnitTests.OpenAPI_20;
 public class PrimitiveJsonConverterTests
 {
     [Theory]
-    [InlineData("integer", "one")]
-    [InlineData("number", "one")]
-    [InlineData("boolean", "one")]
-    public void InvalidTypes_Converting_ReportError(string type, string value)
-    {
-        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
-            .Should().BeFalse();
-        instance.Should().BeNull();
-        error.Should().NotBeNullOrEmpty();
-    }
-    
-    [Theory]
-    [InlineData("integer", "1")]
-    [InlineData("integer", "1.0")]
-    [InlineData("integer", "-0")]
-    [InlineData("integer",  "-9007199254740991")]
-    [InlineData("integer",  "9007199254740992")]
-    [InlineData("number", "1")]
-    [InlineData("number", "1.0")]
-    [InlineData("number", "-0")]
-    [InlineData("number",  "-9007199254740991")]
-    [InlineData("number",  "9007199254740992")]
-    [InlineData("number",  "1.5")]
-    [InlineData("boolean",  "true")]
-    [InlineData("boolean",  "false")]
-    [InlineData("string",  "false")]
-    [InlineData("string",  "foo")]
-    [InlineData("string",  "1")]
-    [InlineData("string",  "")]
-    [InlineData("string",  "1.5")]
-    public void ValidTypes_Converting_ConvertsSuccessfully(string type, string value)
+    [InlineData("integer", "1", "1")]
+    [InlineData("integer", "1.0", "1.0")]
+    [InlineData("integer", "-0", "-0")]
+    [InlineData("integer",  "-9007199254740991", "-9007199254740991")]
+    [InlineData("integer",  "9007199254740992", "9007199254740992")]
+    // out-of-bound for integer type, still formatted as integer as there is no validation
+    [InlineData("integer",  "9007199254740993", "9007199254740993")]
+    // convert to string if the value is not an integer, but in fact looks like a string
+    [InlineData("integer",  "foo", "\"foo\"")]
+    [InlineData("number", "1", "1")]
+    [InlineData("number", "1.0", "1.0")]
+    [InlineData("number", "-0", "-0")]
+    [InlineData("number",  "-9007199254740991", "-9007199254740991")]
+    [InlineData("number",  "9007199254740992", "9007199254740992")]
+    [InlineData("number",  "1.5", "1.5")]
+    // convert to string if the value is not a number, but in fact looks like a string
+    [InlineData("number",  "foo", "\"foo\"")]
+    [InlineData("boolean",  "true", "true")]
+    [InlineData("boolean",  "false", "false")]
+    // convert to string if the value is not a boolean, but in fact looks like a string
+    [InlineData("boolean",  "foo", "\"foo\"")]
+    [InlineData("string",  "false", "\"false\"")]
+    [InlineData("string",  "foo", "\"foo\"")]
+    [InlineData("string",  "1", "\"1\"")]
+    [InlineData("string",  "", "\"\"")]
+    [InlineData("string",  "1.5", "\"1.5\"")]
+    public void ValidTypes_Converting_ConvertsSuccessfully(string type, string value, string jsonValue)
     {
         PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
             .Should().BeTrue();
         error.Should().BeNull();
         instance.Should().NotBeNull();
-        instance.ToJsonString().Trim('"').Should().Be(value);
+        instance.ToJsonString().Should().Be(jsonValue);
     }
 }

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/SchemaParameterValueConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_20/SchemaParameterValueConverterTests.cs
@@ -260,91 +260,41 @@ public class SchemaParameterValueConverterTests
 
     public static readonly TheoryData<string, string?[], bool, string?> String =
         new TheoryData<string, string?[], bool, string?>()
-            .AddRange(CreateString(AllParameterLocations));
-
-    private static (string, string?[], bool, string?)[] CreateString(params string[] ins) =>
-        ins.Select<string, (string, string?[], bool, string?)>(@in =>
-        {
-            var hasKey = LocationToHasKeyMap[@in];
-            var key = hasKey ? "color=" : "";
-            return (
-                $$"""
-                  {
-                      "name": "color",
-                      "in": "{{@in}}",
-                      "type": "string"
-                  }
-                  """,
-                [$"{key}test"],
-                true,
-                "\"test\""
-            );
-        }).ToArray();
+            .AddRange(
+                CreateTestScenarios("string", AllParameterLocations, ["\"1.2\"", "\"test\""]));
 
     public static readonly TheoryData<string, string?[], bool, string?> Number =
         new TheoryData<string, string?[], bool, string?>()
-            .AddRange(CreateNumber(AllParameterLocations));
-    private static (string, string?[], bool, string?)[] CreateNumber(params string[] ins) =>
-        ins.Select<string, (string, string?[], bool, string?)>(@in =>
-        {
-            var hasKey = LocationToHasKeyMap[@in];
-            var key = hasKey ? "color=" : "";
-            return (
-                $$"""
-                  {
-                      "name": "color",
-                      "in": "{{@in}}",
-                      "type": "number"
-                  }
-                  """,
-                [$"{key}1.2"],
-                true,
-                "1.2"
-            );
-        }).ToArray();
+            .AddRange(
+                CreateTestScenarios("number", AllParameterLocations, ["1.2", "\"foo\""]));
 
     public static readonly TheoryData<string, string?[], bool, string?> Integer =
         new TheoryData<string, string?[], bool, string?>()
-            .AddRange(CreateInteger(AllParameterLocations));
-
-    private static (string, string?[], bool, string?)[] CreateInteger(params string[] ins) =>
-        ins.Select<string, (string, string?[], bool, string?)>(@in =>
-        {
-            var hasKey = LocationToHasKeyMap[@in];
-            var key = hasKey ? "color=" : "";
-            return (
-                $$"""
-                  {
-                      "name": "color",
-                      "in": "{{@in}}",
-                      "type": "integer"
-                  }
-                  """,
-                [$"{key}1"],
-                true,
-                "1"
-            );
-        }).ToArray();
+            .AddRange(
+                CreateTestScenarios("integer", AllParameterLocations, ["1", "false", "\"foo\""]));
 
     public static readonly TheoryData<string, string?[], bool, string?> Boolean =
         new TheoryData<string, string?[], bool, string?>()
-            .AddRange(CreateBoolean(AllParameterLocations));
-    private static (string, string?[], bool, string?)[] CreateBoolean(params string[] ins) =>
-        ins.Select<string, (string, string?[], bool, string?)>(@in =>
-        {
-            var hasKey = LocationToHasKeyMap[@in];
-            var key = hasKey ? "color=" : "";
-            return (
-                $$"""
+            .AddRange(
+                CreateTestScenarios("boolean", AllParameterLocations, ["true", "\"foo\""]));
+    
+    private static (string, string?[], bool, string?)[] CreateTestScenarios(string type, string[] ins,
+        string[] jsonValues) =>
+        ins.SelectMany(@in =>
+                jsonValues.Select(val =>
+                    CreateValue(@in, type, val)))
+            .ToArray();
+
+    private static (string, string?[], bool, string?) CreateValue(string @in, string type, string jsonValue)
+    {
+        var hasKey = LocationToHasKeyMap[@in];
+        var key = hasKey ? "color=" : "";
+        return ($$"""
                   {
                       "name": "color",
                       "in": "{{@in}}",
-                      "type": "boolean"
+                      "type": "{{type}}"
                   }
-                  """,
-                [$"{key}true"],
-                true,
-                "true"
-            );
-        }).ToArray();
+                  """, [$"{key}{jsonValue.Trim('"')}"], true, jsonValue);
+    }
 }

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/PrimitiveJsonConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/PrimitiveJsonConverterTests.cs
@@ -6,42 +6,52 @@ namespace OpenAPI.ParameterStyleParsers.UnitTests;
 public class PrimitiveJsonConverterTests
 {
     [Theory]
-    [InlineData(InstanceType.Integer, "one")]
-    [InlineData(InstanceType.Number, "one")]
-    [InlineData(InstanceType.Boolean, "one")]
-    public void InvalidTypes_Converting_ReportError(InstanceType type, string value)
-    {
-        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
-            .Should().BeFalse();
-        instance.Should().BeNull();
-        error.Should().NotBeNullOrEmpty();
-    }
-    
-    [Theory]
-    [InlineData(InstanceType.Integer, "1")]
-    [InlineData(InstanceType.Integer, "1.0")]
-    [InlineData(InstanceType.Integer, "-0")]
-    [InlineData(InstanceType.Integer,  "-9007199254740991")]
-    [InlineData(InstanceType.Integer,  "9007199254740992")]
-    [InlineData(InstanceType.Number, "1")]
-    [InlineData(InstanceType.Number, "1.0")]
-    [InlineData(InstanceType.Number, "-0")]
-    [InlineData(InstanceType.Number,  "-9007199254740991")]
-    [InlineData(InstanceType.Number,  "9007199254740992")]
-    [InlineData(InstanceType.Number,  "1.5")]
-    [InlineData(InstanceType.Boolean,  "true")]
-    [InlineData(InstanceType.Boolean,  "false")]
-    [InlineData(InstanceType.String,  "false")]
-    [InlineData(InstanceType.String,  "foo")]
-    [InlineData(InstanceType.String,  "1")]
-    [InlineData(InstanceType.String,  "")]
-    [InlineData(InstanceType.String,  "1.5")]
-    public void ValidTypes_Converting_ConvertsSuccessfully(InstanceType type, string value)
+    [InlineData(InstanceType.Integer, "1", "1")]
+    [InlineData(InstanceType.Integer, "1.0", "1.0")]
+    [InlineData(InstanceType.Integer, "-0", "-0")]
+    [InlineData(InstanceType.Integer,  "-9007199254740991", "-9007199254740991")]
+    [InlineData(InstanceType.Integer,  "9007199254740992", "9007199254740992")]
+    // out-of-bound for integer type, still formatted as integer as there is no validation
+    [InlineData(InstanceType.Integer,  "9007199254740993", "9007199254740993")]
+    // convert to string if the value is not an integer, but in fact looks like a string
+    [InlineData(InstanceType.Integer,  "foo", "\"foo\"")]
+    [InlineData(InstanceType.Number, "1", "1")]
+    [InlineData(InstanceType.Number, "1.0", "1.0")]
+    [InlineData(InstanceType.Number, "-0", "-0")]
+    [InlineData(InstanceType.Number,  "-9007199254740991", "-9007199254740991")]
+    [InlineData(InstanceType.Number,  "9007199254740992", "9007199254740992")]
+    [InlineData(InstanceType.Number,  "1.5", "1.5")]
+    // convert to string if the value is not a number, but in fact looks like a string
+    [InlineData(InstanceType.Number,  "foo", "\"foo\"")]
+    [InlineData(InstanceType.Boolean,  "true", "true")]
+    [InlineData(InstanceType.Boolean,  "false", "false")]
+    // convert to string if the value is not a boolean, but in fact looks like a string
+    [InlineData(InstanceType.Boolean,  "foo", "\"foo\"")]
+    [InlineData(InstanceType.String,  "false", "\"false\"")]
+    [InlineData(InstanceType.String,  "foo", "\"foo\"")]
+    [InlineData(InstanceType.String,  "1", "\"1\"")]
+    [InlineData(InstanceType.String,  "", "\"\"")]
+    [InlineData(InstanceType.String,  "1.5", "\"1.5\"")]
+    public void ValidTypes_Converting_ConvertsSuccessfully(InstanceType type, string value, string jsonValue)
     {
         PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
             .Should().BeTrue();
         error.Should().BeNull();
         instance.Should().NotBeNull();
-        instance.ToJsonString().Trim('"').Should().Be(value);
+        instance.ToJsonString().Should().Be(jsonValue);
+    }
+    
+    [Theory]
+    [InlineData(InstanceType.Integer,  null)]
+    [InlineData(InstanceType.Number,  null)]
+    [InlineData(InstanceType.Boolean,  null)]
+    [InlineData(InstanceType.String,  null)]
+    [InlineData(InstanceType.Null,  null)]
+    public void Null_Converting_ConvertsSuccessfully(InstanceType type, string value)
+    {
+        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
+            .Should().BeTrue();
+        error.Should().BeNull();
+        instance.Should().BeNull();
     }
 }

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/PrimitiveJsonConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/PrimitiveJsonConverterTests.cs
@@ -1,0 +1,47 @@
+﻿using OpenAPI.ParameterStyleParsers.JsonSchema;
+using OpenAPI.ParameterStyleParsers.ParameterParsers.Primitive;
+
+namespace OpenAPI.ParameterStyleParsers.UnitTests;
+
+public class PrimitiveJsonConverterTests
+{
+    [Theory]
+    [InlineData(InstanceType.Integer, "one")]
+    [InlineData(InstanceType.Number, "one")]
+    [InlineData(InstanceType.Boolean, "one")]
+    public void InvalidTypes_Converting_ReportError(InstanceType type, string value)
+    {
+        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
+            .Should().BeFalse();
+        instance.Should().BeNull();
+        error.Should().NotBeNullOrEmpty();
+    }
+    
+    [Theory]
+    [InlineData(InstanceType.Integer, "1")]
+    [InlineData(InstanceType.Integer, "1.0")]
+    [InlineData(InstanceType.Integer, "-0")]
+    [InlineData(InstanceType.Integer,  "-9007199254740991")]
+    [InlineData(InstanceType.Integer,  "9007199254740992")]
+    [InlineData(InstanceType.Number, "1")]
+    [InlineData(InstanceType.Number, "1.0")]
+    [InlineData(InstanceType.Number, "-0")]
+    [InlineData(InstanceType.Number,  "-9007199254740991")]
+    [InlineData(InstanceType.Number,  "9007199254740992")]
+    [InlineData(InstanceType.Number,  "1.5")]
+    [InlineData(InstanceType.Boolean,  "true")]
+    [InlineData(InstanceType.Boolean,  "false")]
+    [InlineData(InstanceType.String,  "false")]
+    [InlineData(InstanceType.String,  "foo")]
+    [InlineData(InstanceType.String,  "1")]
+    [InlineData(InstanceType.String,  "")]
+    [InlineData(InstanceType.String,  "1.5")]
+    public void ValidTypes_Converting_ConvertsSuccessfully(InstanceType type, string value)
+    {
+        PrimitiveJsonConverter.TryConvert(value, type, out var instance, out var error)
+            .Should().BeTrue();
+        error.Should().BeNull();
+        instance.Should().NotBeNull();
+        instance.ToJsonString().Trim('"').Should().Be(value);
+    }
+}


### PR DESCRIPTION
Parse the value as string if the value isn't convertible as the intended json type.