### PR TITLE
Fix parsing quoted simple arrays

### DIFF
--- a/src/OpenAPI.ParameterStyleParsers/Extensions/StringExtensions.cs
+++ b/src/OpenAPI.ParameterStyleParsers/Extensions/StringExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace OpenAPI.ParameterStyleParsers.Extensions;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Splits a string using a separator while honoring quoted separators
+    /// </summary>
+    /// <param name="value">String to be split</param>
+    /// <param name="separator">Separator</param>
+    /// <returns>A list of separated items</returns>
+    internal static List<string> SplitWithQuotation(this string value, char separator)
+    {
+        if (separator == '"')
+            throw new ArgumentException("Cannot split with the quote character", nameof(separator));
+        var result = new List<string>();
+        var inQuotes = false;
+        var start = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            switch (value[i])
+            {
+                case '"' when inQuotes && i > 0 && value[i-1] == '\\':
+                    break;
+                case '"':
+                    inQuotes = !inQuotes;
+                    break;
+                case var chr when !inQuotes && chr == separator:
+                    result.Add(value[start..i]);
+                    start = i + 1;
+                    break;
+            }
+        }
+        result.Add(value[start..]);
+        return result;
+    }
+}

--- a/src/OpenAPI.ParameterStyleParsers/IParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/IParameterValueParser.cs
@@ -32,4 +32,9 @@ public interface IParameterValueParser
     /// Parameter name is included in the value, i.e. [parameter name]=[value] vs [value], see style examples in OAS.
     /// </summary>
     bool ValueIncludesParameterName { get; }
+    
+    /// <summary>
+    /// The delimiter between array items and object properties
+    /// </summary>
+    public string Delimiter { get; }
 }

--- a/src/OpenAPI.ParameterStyleParsers/IValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/IValueParser.cs
@@ -13,4 +13,5 @@ internal interface IValueParser
     string? Serialize(JsonNode? instance);
     
     bool ValueIncludesParameterName { get; }
+    string Delimiter { get; }
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/Parameter.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/Parameter.cs
@@ -270,7 +270,7 @@ public record Parameter : IParameter
     /// Does the parameter value include keys, i.e. key=value
     /// </summary>
     public bool ValueIncludesKey { get; }
-
+    
     /// <inheritdoc cref="GetSchema(JsonObject)" />
     [PublicAPI]
     public static JsonNode? GetSchema(string parameterSpecification)

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/ArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/ArrayValueParser.cs
@@ -10,6 +10,7 @@ internal abstract class ArrayValueParser : IValueParser
 
     protected string ParameterName { get; }
     public bool ValueIncludesParameterName { get; }
+    public abstract string Delimiter { get; }
 
     protected ArrayValueParser(Parameter parameter)
     {

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/CharacterSeparatedValuesArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/CharacterSeparatedValuesArrayValueParser.cs
@@ -6,7 +6,8 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Array;
 internal abstract class CharacterSeparatedValuesArrayValueParser(Parameter parameter) : ArrayValueParser(parameter)
 {
     protected abstract char Separator { get; }
-    
+    public override string Delimiter => Separator.ToString();
+
     public override bool TryParse(
         string? input,
         out JsonNode? array,

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/MultiArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Array/MultiArrayValueParser.cs
@@ -5,13 +5,15 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi20.ParameterParsers.Array;
 
 internal sealed class MultiArrayValueParser(Parameter parameter) : ArrayValueParser(parameter)
 {
+    public override string Delimiter => "&";
+
     public override bool TryParse(
         string? value,
         out JsonNode? array,
         [NotNullWhen(false)] out string? error)
     {
         var arrayValues = value?
-            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Split(Delimiter, StringSplitOptions.RemoveEmptyEntries)
             .Select(expression =>
             {
                 var valueAndKey = expression.Split('=');
@@ -22,6 +24,6 @@ internal sealed class MultiArrayValueParser(Parameter parameter) : ArrayValuePar
     }
 
     protected override string Serialize(string?[] values) =>
-        string.Join('&',
+        string.Join(Delimiter,
             values.Select(value => $"{ParameterName}={value}"));
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/ParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/ParameterValueParser.cs
@@ -57,4 +57,7 @@ public sealed class ParameterValueParser : IParameterValueParser
 
     /// <inheritdoc />
     public bool ValueIncludesParameterName { get; }
+
+    /// <inheritdoc />
+    public string Delimiter => _valueParser.Delimiter;
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi20/ParameterParsers/Primitive/PrimitiveValueParser.cs
@@ -61,7 +61,8 @@ internal abstract class PrimitiveValueParser : IValueParser
     public string? Serialize(JsonNode? instance) =>
         instance == null ? null : Serialize(Uri.EscapeDataString(instance.ToString()));
 
-    public bool ValueIncludesParameterName { get; } 
+    public bool ValueIncludesParameterName { get; }
+    public string Delimiter => string.Empty;
 
     protected abstract string Serialize(string value);
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi30/ParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi30/ParameterValueParser.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
 using JetBrains.Annotations;
-using OpenAPI.ParameterStyleParsers.ParameterParsers;
 
 namespace OpenAPI.ParameterStyleParsers.OpenApi30;
 
@@ -20,6 +19,9 @@ public sealed class ParameterValueParser : IParameterValueParser
 
     /// <inheritdoc />
     public bool ValueIncludesParameterName => _innerParser.ValueIncludesParameterName;
+
+    /// <inheritdoc />
+    public string Delimiter => _innerParser.Delimiter;
 
     /// <summary>
     /// Creates a parameter value parser corresponding to the specified parameter

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/ArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/ArrayValueParser.cs
@@ -47,6 +47,7 @@ internal abstract class ArrayValueParser(Parameter parameter) : IValueParser
     }
 
     public abstract bool ValueIncludesParameterName { get; }
+    public abstract string Delimiter { get; }
 
     protected abstract string Serialize(string?[] values);
 

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/FormArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/FormArrayValueParser.cs
@@ -16,7 +16,7 @@ internal sealed class FormArrayValueParser(Parameter parameter) : ArrayValuePars
             {
                 var valueAndKey = expression.Split('=');
                 var value = valueAndKey.Length == 1 ? string.Empty : valueAndKey.Last();
-                return Explode ? [value] : value.Split(',');
+                return Explode ? [value] : value.Split(Delimiter);
             })
             .ToArray();
         
@@ -24,10 +24,11 @@ internal sealed class FormArrayValueParser(Parameter parameter) : ArrayValuePars
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => Explode ? "&" : ",";
 
     protected override string Serialize(string?[] values)
     {
-        var serialized = string.Join(Explode ? '&' : ',',
+        var serialized = string.Join(Delimiter,
             values.Select(value => Explode ? $"{ParameterName}={value}" : value));
         return Explode ? serialized : $"{ParameterName}={serialized}";
     }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/LabelArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/LabelArrayValueParser.cs
@@ -11,12 +11,13 @@ internal sealed class LabelArrayValueParser(Parameter parameter) : ArrayValuePar
         [NotNullWhen(false)] out string? error)
     {
         var arrayValues = value?
-            .Split('.')[1..];
+            .Split(Delimiter)[1..];
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 
     public override bool ValueIncludesParameterName => false;
+    public override string Delimiter => ".";
 
     protected override string Serialize(string?[] values) => 
-        $".{string.Join('.', values)}";
+        $".{string.Join(Delimiter, values)}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/MatrixArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/MatrixArrayValueParser.cs
@@ -16,17 +16,18 @@ internal sealed class MatrixArrayValueParser(Parameter parameter) : ArrayValuePa
             {
                 var valueAndKey = expression.Split('=');
                 var value = valueAndKey.Length == 1 ? string.Empty : valueAndKey.Last();
-                return Explode ? [value] : value.Split(',');
+                return Explode ? [value] : value.Split(Delimiter);
             })
             .ToArray();
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => Explode ? ";" : ",";
 
     protected override string Serialize(string?[] values)
     {
-        var serialized = string.Join(Explode ? ';' : ',',
+        var serialized = string.Join(Delimiter,
             values.Select(value => Explode ? $"{ParameterName}{(string.IsNullOrEmpty(value) ? "" : "=")}{value}" : value));
         return $";{(Explode ? serialized : $"{ParameterName}={serialized}")}";
     }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/PipeDelimitedArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/PipeDelimitedArrayValueParser.cs
@@ -16,7 +16,7 @@ internal sealed class PipeDelimitedArrayValueParser(Parameter parameter) : Array
             {
                 var valueAndKey = expression.Split('=');
                 var value = valueAndKey.Length == 1 ? string.Empty : valueAndKey.Last();
-                return Explode ? [value] : value.Split('|');
+                return Explode ? [value] : value.Split(Delimiter);
             })
             .ToArray();
 
@@ -24,10 +24,11 @@ internal sealed class PipeDelimitedArrayValueParser(Parameter parameter) : Array
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => Explode ? "&" : "|";
 
     protected override string Serialize(string?[] values)
     {
-        var serialized = string.Join(Explode ? '&' : '|',
+        var serialized = string.Join(Delimiter,
             values.Select(value => Explode ? $"{ParameterName}={value}" : value));
         return Explode ? serialized : $"{ParameterName}={serialized}";
     }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/SimpleArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/SimpleArrayValueParser.cs
@@ -11,12 +11,13 @@ internal sealed class SimpleArrayValueParser(Parameter parameter) : ArrayValuePa
         [NotNullWhen(false)] out string? error)
     {
         var arrayValues = value?
-            .Split(',');
+            .Split(Delimiter);
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 
     public override bool ValueIncludesParameterName => false;
+    public override string Delimiter => ",";
 
     protected override string Serialize(string?[] values) => 
-        string.Join(',', values);
+        string.Join(Delimiter, values);
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/SpaceDelimitedArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Array/SpaceDelimitedArrayValueParser.cs
@@ -16,7 +16,7 @@ internal sealed class SpaceDelimitedArrayValueParser(Parameter parameter) : Arra
             {
                 var valueAndKey = expression.Split('=');
                 var value = valueAndKey.Length == 1 ? string.Empty : valueAndKey.Last();
-                return Explode ? [value] : value.Split("%20");
+                return Explode ? [value] : value.Split(Delimiter);
             })
             .ToArray();
 
@@ -24,10 +24,11 @@ internal sealed class SpaceDelimitedArrayValueParser(Parameter parameter) : Arra
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => Explode ? "&" : "%20"; 
 
     protected override string Serialize(string?[] values)
     {
-        var serialized = string.Join(Explode ? "&" : "%20",
+        var serialized = string.Join(Delimiter,
             values.Select(value => Explode ? $"{ParameterName}={value}" : value));
         return Explode ? serialized : $"{ParameterName}={serialized}";
     }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/MissingSchemaTypeValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/MissingSchemaTypeValueParser.cs
@@ -30,4 +30,5 @@ internal sealed class MissingSchemaTypeValueParser : IValueParser
         _valueParser.Serialize(instance);
 
     public bool ValueIncludesParameterName => _valueParser.ValueIncludesParameterName;
+    public string Delimiter => _valueParser.Delimiter;
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/DeepObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/DeepObjectValueParser.cs
@@ -6,6 +6,7 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class DeepObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => "&";
 
     public override bool TryParse(
         string? value,
@@ -20,7 +21,7 @@ internal sealed class DeepObjectValueParser(Parameter parameter) : ObjectValuePa
         }
 
         var keyAndValues = value?
-            .Split('&')
+            .Split(Delimiter)
             .SelectMany(value =>
             {
                 var keyAndValue = value
@@ -37,5 +38,5 @@ internal sealed class DeepObjectValueParser(Parameter parameter) : ObjectValuePa
     }
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        string.Join('&', properties.Select(pair => $"{ParameterName}[{pair.Key}]={pair.Value}"));
+        string.Join(Delimiter, properties.Select(pair => $"{ParameterName}[{pair.Key}]={pair.Value}"));
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/FormObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/FormObjectValueParser.cs
@@ -6,6 +6,7 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class FormObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => ",";
 
     public override bool TryParse(
         string? value,
@@ -22,10 +23,10 @@ internal sealed class FormObjectValueParser(Parameter parameter) : ObjectValuePa
         var keyAndValues = value?
             .Split('=')
             .Last()
-            .Split(',');
+            .Split(Delimiter);
         return TryGetObjectProperties(keyAndValues, out obj, out error);
     }
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        $";{ParameterName}={string.Join(',', properties.Select(pair => $"{pair.Key},{pair.Value}"))}";
+        $";{ParameterName}={string.Join(Delimiter, properties.Select(pair => $"{pair.Key}{Delimiter}{pair.Value}"))}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/LabelObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/LabelObjectValueParser.cs
@@ -6,6 +6,7 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class LabelObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => false;
+    public override string Delimiter => ".";
 
     public override bool TryParse(
         string? value,
@@ -13,7 +14,7 @@ internal sealed class LabelObjectValueParser(Parameter parameter) : ObjectValueP
         [NotNullWhen(false)] out string? error)
     {
         var keyAndValues = value?
-            .Split('.')[1..];
+            .Split(Delimiter)[1..];
         if (Explode)
         {
             keyAndValues = keyAndValues?
@@ -28,7 +29,7 @@ internal sealed class LabelObjectValueParser(Parameter parameter) : ObjectValueP
     {
         if (!properties.Any())
             return string.Empty;
-        return $".{string.Join('.',
+        return $".{string.Join(Delimiter,
             properties.Select(pair => $"{pair.Key}{(Explode ? "=" : ".")}{pair.Value}"))}";
     }
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/MatrixObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/MatrixObjectValueParser.cs
@@ -6,6 +6,7 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class MatrixObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => !Explode;
+    public override string Delimiter => Explode ? ";" : ",";
 
     public override bool TryParse(
         string? value,
@@ -19,7 +20,7 @@ internal sealed class MatrixObjectValueParser(Parameter parameter) : ObjectValue
                 var valueAndKey = expression.Split('=');
                 var key = valueAndKey[0];
                 var value = valueAndKey.Length == 1 ? string.Empty : valueAndKey.Last();
-                return Explode ? [key, value] : value.Split(',');
+                return Explode ? [key, value] : value.Split(Delimiter);
             })
             .ToArray();
 
@@ -27,7 +28,7 @@ internal sealed class MatrixObjectValueParser(Parameter parameter) : ObjectValue
     }
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        $";{(ValueIncludesParameterName ? $"{ParameterName}=" : "")}{string.Join(ValueIncludesParameterName ? ',' : ';',
+        $";{(ValueIncludesParameterName ? $"{ParameterName}=" : "")}{string.Join(Delimiter,
             properties.Select(property =>
                 $"{property.Key}{(ValueIncludesParameterName ? "," : string.IsNullOrEmpty(property.Value) ? "" : "=")}{property.Value}"))}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/ObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/ObjectValueParser.cs
@@ -13,6 +13,7 @@ internal abstract class ObjectValueParser(Parameter parameter) : IValueParser
 
     protected bool Explode { get; } = parameter.Explode;
     public abstract bool ValueIncludesParameterName { get; }
+    public abstract string Delimiter { get; }
     protected string ParameterName { get; } = parameter.Name;
 
     internal static ObjectValueParser Create(Parameter parameter) =>

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/PipeDelimitedObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/PipeDelimitedObjectValueParser.cs
@@ -20,12 +20,13 @@ internal sealed class PipeDelimitedObjectValueParser(Parameter parameter) : Obje
         var keyAndValues = value?
             .Split('=')
             .Last()    
-            .Split('|');
+            .Split(Delimiter);
         return TryGetObjectProperties(keyAndValues, out obj, out error);
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => "|";
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        $"{ParameterName}={string.Join('|', properties.Select(property => $"{property.Key}|{property.Value}"))}";
+        $"{ParameterName}={string.Join(Delimiter, properties.Select(property => $"{property.Key}{Delimiter}{property.Value}"))}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/SimpleObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/SimpleObjectValueParser.cs
@@ -6,13 +6,14 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class SimpleObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => false;
+    public override string Delimiter => ",";
 
     public override bool TryParse(
         string? value,
         out JsonNode? obj,
         [NotNullWhen(false)] out string? error)
     {
-        var keyAndValues = value?.Split(',');
+        var keyAndValues = value?.Split(Delimiter);
         if (Explode)
         {
             keyAndValues = keyAndValues?
@@ -24,6 +25,6 @@ internal sealed class SimpleObjectValueParser(Parameter parameter) : ObjectValue
     }
 
     protected override string Serialize(IDictionary<string, string?> properties) => 
-        string.Join(',', 
+        string.Join(Delimiter, 
             properties.Select(pair => $"{pair.Key}{(Explode ? "=" : ",")}{pair.Value}"));
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/SpaceDelimitedObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Object/SpaceDelimitedObjectValueParser.cs
@@ -6,6 +6,7 @@ namespace OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers.Object;
 internal sealed class SpaceDelimitedObjectValueParser(Parameter parameter) : ObjectValueParser(parameter)
 {
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => "%20";
 
     public override bool TryParse(
         string? value,
@@ -22,10 +23,10 @@ internal sealed class SpaceDelimitedObjectValueParser(Parameter parameter) : Obj
         var keyAndValues = value?
             .Split('=')
             .Last()
-            .Split("%20");
+            .Split(Delimiter);
         return TryGetObjectProperties(keyAndValues, out obj, out error);
     }
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        $"{ParameterName}={string.Join("%20", properties.Select(property => $"{property.Key}%20{property.Value}"))}";
+        $"{ParameterName}={string.Join(Delimiter, properties.Select(property => $"{property.Key}{Delimiter}{property.Value}"))}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Primitive/PrimitiveValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterParsers/Primitive/PrimitiveValueParser.cs
@@ -67,5 +67,6 @@ internal abstract class PrimitiveValueParser : IValueParser
         instance == null ? null : Serialize(Uri.EscapeDataString(instance.ToString()));
 
     public abstract bool ValueIncludesParameterName { get; }
+    public string Delimiter => string.Empty;
     protected abstract string Serialize(string value);
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi31/ParameterValueParser.cs
@@ -24,6 +24,10 @@ public sealed class ParameterValueParser : IParameterValueParser
     /// <inheritdoc />
     public bool ValueIncludesParameterName { get; }
 
+
+    /// <inheritdoc />
+    public string Delimiter => _valueParser.Delimiter;
+
     /// <summary>
     /// Creates a parameter value parser corresponding to the specified parameter
     /// </summary>

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/ArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/ArrayValueParser.cs
@@ -35,6 +35,7 @@ internal abstract class ArrayValueParser(Parameter parameter) : IValueParser
     }
 
     public abstract bool ValueIncludesParameterName { get; }
+    public abstract string Delimiter { get; }
 
     protected abstract string Serialize(string?[] values);
 

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/CookieArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/CookieArrayValueParser.cs
@@ -21,7 +21,7 @@ internal sealed class CookieArrayValueParser(Parameter parameter) : ArrayValuePa
         if (Explode)
         {
             arrayValues = value
-                .Split("; ", StringSplitOptions.RemoveEmptyEntries)
+                .Split(Delimiter, StringSplitOptions.RemoveEmptyEntries)
                 .Select(expression =>
                 {
                     var parts = expression.Split('=', 2);
@@ -33,16 +33,17 @@ internal sealed class CookieArrayValueParser(Parameter parameter) : ArrayValuePa
         {
             var parts = value.Split('=', 2);
             var valuesStr = parts.Length > 1 ? parts[1] : string.Empty;
-            arrayValues = valuesStr.Split(',');
+            arrayValues = valuesStr.Split(Delimiter);
         }
 
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 
     public override bool ValueIncludesParameterName => true;
+    public override string Delimiter => Explode ? "; " : ","; 
 
     protected override string Serialize(string?[] values) =>
         Explode
-            ? string.Join("; ", values.Select(v => $"{ParameterName}={v}"))
-            : $"{ParameterName}={string.Join(',', values)}";
+            ? string.Join(Delimiter, values.Select(v => $"{ParameterName}={v}"))
+            : $"{ParameterName}={string.Join(Delimiter, values)}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/SimpleArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/SimpleArrayValueParser.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Nodes;
+using OpenAPI.ParameterStyleParsers.Extensions;
 
 namespace OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers.Array;
 
@@ -10,7 +11,7 @@ internal sealed class SimpleArrayValueParser(Parameter parameter) : ArrayValuePa
         out JsonNode? array,
         [NotNullWhen(false)] out string? error)
     {
-        var arrayValues = value?.Split(',');
+        var arrayValues = value?.SplitWithQuotation(',');
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/SimpleArrayValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Array/SimpleArrayValueParser.cs
@@ -11,12 +11,15 @@ internal sealed class SimpleArrayValueParser(Parameter parameter) : ArrayValuePa
         out JsonNode? array,
         [NotNullWhen(false)] out string? error)
     {
-        var arrayValues = value?.SplitWithQuotation(',');
+        var arrayValues = value?.SplitWithQuotation(DelimiterAsChr);
         return TryGetArrayItems(arrayValues, out array, out error);
     }
 
     public override bool ValueIncludesParameterName => false;
+    
+    private const char DelimiterAsChr = ',';
+    public override string Delimiter { get; } = DelimiterAsChr.ToString();
 
     protected override string Serialize(string?[] values) =>
-        string.Join(',', values);
+        string.Join(DelimiterAsChr, values);
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/CookieObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/CookieObjectValueParser.cs
@@ -25,7 +25,7 @@ internal sealed class CookieObjectValueParser(Parameter parameter) : ObjectValue
         if (Explode)
         {
             // Cookie style exploded: "key1=value1; key2=value2"
-            var pairs = value.Split("; ", StringSplitOptions.RemoveEmptyEntries);
+            var pairs = value.Split(Delimiter, StringSplitOptions.RemoveEmptyEntries);
             var jsonObject = new JsonObject();
 
             foreach (var pair in pairs)
@@ -59,13 +59,14 @@ internal sealed class CookieObjectValueParser(Parameter parameter) : ObjectValue
             return false;
         }
 
-        var keyAndValues = nameValue[1].Split(',');
+        var keyAndValues = nameValue[1].Split(Delimiter);
         return TryGetObjectProperties(keyAndValues, out obj, out error);
     }
 
     public override bool ValueIncludesParameterName => !Explode;
+    public override string Delimiter => Explode ? "; " : ",";
 
     protected override string Serialize(IDictionary<string, string?> properties) => Explode
-        ? string.Join("; ", properties.Select(p => $"{p.Key}={p.Value}"))
-        : $"{ParameterName}={string.Join(',', properties.Select(p => $"{p.Key},{p.Value}"))}";
+        ? string.Join(Delimiter, properties.Select(p => $"{p.Key}={p.Value}"))
+        : $"{ParameterName}={string.Join(Delimiter, properties.Select(p => $"{p.Key}{Delimiter}{p.Value}"))}";
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/ObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/ObjectValueParser.cs
@@ -34,6 +34,7 @@ internal abstract class ObjectValueParser(Parameter parameter) : IValueParser
     }
 
     public abstract bool ValueIncludesParameterName { get; }
+    public abstract string Delimiter { get; }
 
     protected abstract string Serialize(IDictionary<string, string?> properties);
 

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/SimpleObjectValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Object/SimpleObjectValueParser.cs
@@ -10,7 +10,7 @@ internal sealed class SimpleObjectValueParser(Parameter parameter) : ObjectValue
         out JsonNode? obj,
         [NotNullWhen(false)] out string? error)
     {
-        var keyAndValues = value?.Split(',');
+        var keyAndValues = value?.Split(Delimiter);
         if (Explode)
         {
             keyAndValues = keyAndValues?
@@ -21,7 +21,8 @@ internal sealed class SimpleObjectValueParser(Parameter parameter) : ObjectValue
     }
 
     public override bool ValueIncludesParameterName => false;
+    public override string Delimiter => ",";
 
     protected override string Serialize(IDictionary<string, string?> properties) =>
-        string.Join(',', properties.Select(pair => $"{pair.Key}{(Explode ? "=" : ",")}{pair.Value}"));
+        string.Join(Delimiter, properties.Select(pair => $"{pair.Key}{(Explode ? "=" : ",")}{pair.Value}"));
 }

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/ParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/ParameterValueParser.cs
@@ -5,7 +5,6 @@ using OpenAPI.ParameterStyleParsers.JsonSchema;
 using OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers.Array;
 using OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers.Object;
 using OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers.Primitive;
-using OpenAPI.ParameterStyleParsers.ParameterParsers;
 using OpenAPI.ParameterStyleParsers.OpenApi31.ParameterParsers;
 
 namespace OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers;
@@ -26,6 +25,9 @@ public sealed class ParameterValueParser : IParameterValueParser
 
     /// <inheritdoc />
     public bool ValueIncludesParameterName { get; }
+
+    /// <inheritdoc />
+    public string Delimiter => _valueParser.Delimiter;
 
     /// <summary>
     /// Creates a parameter value parser corresponding to the specified parameter

--- a/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Primitive/PrimitiveValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/OpenApi32/ParameterParsers/Primitive/PrimitiveValueParser.cs
@@ -49,6 +49,7 @@ internal abstract class PrimitiveValueParser(Parameter parameter) : IValueParser
         instance == null ? null : Serialize(instance.ToString());
 
     public abstract bool ValueIncludesParameterName { get; }
+    public string Delimiter => string.Empty;
 
     protected abstract string Serialize(string value);
 }

--- a/src/OpenAPI.ParameterStyleParsers/ParameterParsers/ParameterValueParser.cs
+++ b/src/OpenAPI.ParameterStyleParsers/ParameterParsers/ParameterValueParser.cs
@@ -19,6 +19,9 @@ public sealed class ParameterValueParser : IParameterValueParser
     /// <inheritdoc />
     public bool ValueIncludesParameterName => _innerParser.ValueIncludesParameterName;
 
+    /// <inheritdoc />
+    public string Delimiter => _innerParser.Delimiter;
+
     /// <summary>
     /// Creates a parameter value parser corresponding to the specified parameter
     /// </summary>

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_32/SchemaParameterValueConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenAPI_32/SchemaParameterValueConverterTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using OpenAPI.ParameterStyleParsers.OpenApi32.ParameterParsers;
 
@@ -200,7 +201,7 @@ public class SchemaParameterValueConverterTests
         else
         {
             jsonInstance.Should().NotBeNull();
-            instance.ToJsonString().Should().BeEquivalentTo(jsonInstance);
+            instance.ToJsonString().Should().Be(JsonNode.Parse(jsonInstance)?.ToJsonString());
         }
     }
 
@@ -365,6 +366,57 @@ public class SchemaParameterValueConverterTests
             ["hello%20world,foo%2Cbar"],
             true,
             """["hello%20world","foo%2Cbar"]""",
+            false
+        },
+        {
+            """
+            {
+                "name": "X-Quotes",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             "1","2"
+             """],
+            true,
+            """
+            ["\"1\"","\"2\""]
+            """,
+            false
+        },
+        {
+            """
+            {
+                "name": "QuotedCommas",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             "1,","2"
+             """],
+            true,
+            """
+            ["\"1,\"","\"2\""]
+            """,
+            false
+        },
+        {
+            """
+            {
+                "name": "DoubleQuotedCommas",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             "1\","
+             """],
+            true,
+            """"
+            ["\"1\\\",\""]
+            """",
             false
         }
     };

--- a/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenApi_31/SchemaParameterValueConverterTests.cs
+++ b/tests/OpenAPI.ParameterStyleParsers.UnitTests/OpenApi_31/SchemaParameterValueConverterTests.cs
@@ -1,6 +1,4 @@
 ﻿using System.Text.Json.Nodes;
-using OpenAPI.ParameterStyleParsers.JsonSchema;
-using OpenAPI.ParameterStyleParsers.ParameterParsers;
 
 namespace OpenAPI.ParameterStyleParsers.UnitTests.OpenApi_31;
 
@@ -244,16 +242,8 @@ public class SchemaParameterValueConverterTests
         string? jsonInstance,
         bool expectedValueIncludesParameterName)
     {
-        var parameterJsonNode = JsonNode.Parse(parameterJson)!;
-        var reader = new JsonNodeReader(parameterJsonNode);
-        var schema = new JsonSchema202012(parameterJsonNode["schema"]);
         var parameter =
-            OpenApi31.Parameter.Parse(
-                reader.Read("name").GetValue<string>(),
-                reader.Read("style").GetValue<string>(),
-                reader.Read("in").GetValue<string>(),
-                reader.Read("explode").GetValue<bool>(),
-                schema);
+            OpenApi31.Parameter.FromOpenApi31ParameterSpecification(parameterJson);
         var parser = OpenApi31.ParameterValueParser.Create(parameter);
         parser.ValueIncludesParameterName.Should().Be(expectedValueIncludesParameterName);
         parser.TryParse(value, out var instance, out var mappingError).Should().Be(shouldMap, mappingError);
@@ -270,7 +260,7 @@ public class SchemaParameterValueConverterTests
         else
         {
             jsonInstance.Should().NotBeNull();
-            instance.ToJsonString().Should().BeEquivalentTo(jsonInstance);
+            instance.ToJsonString().Should().BeEquivalentTo(JsonNode.Parse(jsonInstance)?.ToJsonString());
         }
     }
 
@@ -1464,6 +1454,57 @@ public class SchemaParameterValueConverterTests
             ["test,test2"],
             true,
             "[\"test\",\"test2\"]",
+            false
+        },
+        {
+            """
+            {
+                "name": "X-Quotes",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             %221%22,%222%22
+             """],
+            true,
+            """
+            ["\"1\"","\"2\""]
+            """,
+            false
+        },
+        {
+            """
+            {
+                "name": "QuotedCommas",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             %221%2C%22,%222%22
+             """],
+            true,
+            """
+            ["\"1,\"","\"2\""]
+            """,
+            false
+        },
+        {
+            """
+            {
+                "name": "DoubleQuotedCommas",
+                "in": "header",
+                "schema": { "type": "array", "items": { "type": "string" } }
+            }
+            """,
+            ["""
+             %221%5C%22%2C%22
+             """],
+            true,
+            """"
+            ["\"1\\\",\""]
+            """",
             false
         }
     };


### PR DESCRIPTION
- Since OpenAPI 3.2 states that simple style parameters shall not percent encode values, the parser need to handle quotations.
- Expose `Delimiter` property on parameter value parsers which can help with handling multi values from other abstractions